### PR TITLE
serve from public folder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const express = require('express');
 const app = express();
 
-const publicPath = path.join(__dirname, '..', 'onboarding-app/build');
+const publicPath = path.join(__dirname, '..', 'onboarding-app/public');
 
 const port = process.env.PORT || 7000;
 


### PR DESCRIPTION
#### What does this PR do?
- This PR makes us serve our HTML file from the `public` and not `build` folder